### PR TITLE
Search context proposal

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -17,6 +17,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <kotlin.version>1.0.3</kotlin.version>
         <junit.version>4.12</junit.version>
+        <spek.version>0.1.199</spek.version>
+        <assertj-core.version>3.3.0</assertj-core.version>
     </properties>
 
     <dependencies>
@@ -46,21 +48,20 @@
             <version>${kotlin.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test-junit</artifactId>
-            <version>${kotlin.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.spek</groupId>
+            <artifactId>spek</artifactId>
+            <version>${spek.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test</artifactId>
-            <version>${kotlin.version}</version>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj-core.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/core/src/main/kotlin/com/github/ktoolz/model/SearchResult.kt
+++ b/core/src/main/kotlin/com/github/ktoolz/model/SearchResult.kt
@@ -1,8 +1,0 @@
-package com.github.ktoolz.model
-
-import java.io.File
-
-/**
- * Store a search result
- */
-data class SearchResult(val score: Int, val filename: String, val file: File)

--- a/core/src/main/kotlin/com/github/ktoolz/model/namespace.kt
+++ b/core/src/main/kotlin/com/github/ktoolz/model/namespace.kt
@@ -1,0 +1,13 @@
+package com.github.ktoolz.model
+
+import javaslang.collection.List
+import java.io.File
+
+/**
+ * Store a search result
+ */
+data class SearchResult(val score: Int, val file: File) {
+    val filename: String by lazy { file.name }
+}
+
+data class SearchQuery(val term: String, val contexts: List<String>, val directories: List<String>)

--- a/core/src/main/kotlin/com/github/ktoolz/model/namespace.kt
+++ b/core/src/main/kotlin/com/github/ktoolz/model/namespace.kt
@@ -10,4 +10,6 @@ data class SearchResult(val score: Int, val file: File) {
     val filename: String by lazy { file.name }
 }
 
-data class SearchQuery(val term: String, val contexts: List<String>, val directories: List<String>)
+data class FilterQuery(val name: String, val negated: Boolean = false)
+
+data class SearchQuery(val term: String, val contexts: List<FilterQuery>, val directories: List<String>)

--- a/core/src/main/kotlin/com/github/ktoolz/parser/Parser.kt
+++ b/core/src/main/kotlin/com/github/ktoolz/parser/Parser.kt
@@ -1,0 +1,182 @@
+package com.github.ktoolz.parser
+
+import com.github.ktoolz.model.SearchQuery
+import javaslang.collection.List
+
+// https://www.youtube.com/watch?v=q4BNwnZ4D4o
+infix fun (() -> Any).unless(condition: Boolean) {
+    if (!condition) this()
+}
+
+// https://www.youtube.com/watch?v=weRHyjj34ZE
+infix fun (() -> Any).whenever(condition: Boolean) {
+    if (condition) this()
+}
+
+class ContextParser(val filterNames: List<String>) {
+
+    /**
+     * Mutable version of a SearchQuery used to build it step by step
+     */
+    private class MutableQuery(val term: MutableList<Char> = mutableListOf(),
+                               val directories: MutableList<List<Char>> = mutableListOf(),
+                               val modifiers: MutableList<List<Char>> = mutableListOf()) {
+
+        override fun toString(): String = "$term, $directories, $modifiers"
+        fun toQuery() = SearchQuery(term.joinToString(""),
+                                    List.ofAll(modifiers.map { it.mkString("") }),
+                                    List.ofAll(directories.map { it.mkString("") }))
+    }
+
+    /**
+     * Entry point of this class, parse a String and return a SearchQuery
+     */
+    fun parse(query: String) = neutral(List.ofAll(query.toCharArray()), MutableQuery()).toQuery()
+
+
+    /**
+     * Neutral state of the state machine.
+     *
+     * - If the state machine read a space then it try to deal with it or backtrack to the 'query' state
+     * - Any other char will goes to 'query' state
+     *
+     * If End of Stream reached, simply return the built query
+     */
+    private fun neutral(list: List<Char>, query: MutableQuery): MutableQuery =
+            if (list.isEmpty) query
+            else when (list.head()) {
+                ' ' -> pendingSpace(list.tail(), query) { query(list, query) }
+                else -> query(list, query)
+            }
+
+    /**
+     * A space has been readed. Check if this space is followed by a special char
+     *
+     * - If it's followed by a spacial char (like '/' or '!') go to the corresponding state to deal with it
+     * - If it's followed by another space, keep in the same state
+     * - Any other char will trigger the backtracking
+     *
+     * If End of Stream reached, simply return the built query ignoring the trailing spaces
+     */
+    private fun pendingSpace(list: List<Char>, query: MutableQuery, backtracking: () -> MutableQuery): MutableQuery =
+            if (list.isEmpty) query // do nothing as trailing space is ignored
+            else when (list.head()) {
+                ' ' -> pendingSpace(list.tail(), query, backtracking)
+                '!' -> filter(list.tail(), query, backtracking)
+                '/' -> directory(list.tail(), query, backtracking)
+                else -> backtracking()
+            }
+
+
+    /**
+     * We are reading a filter ('!' char)
+     *
+     * # Read the filter identifier
+     * # Check if it's a valid filter name
+     * ## If yes, add it, then process the rest of the string as normal String (neutral state)
+     * ## If no, trigger backtracking
+     *
+     * If End of Stream reached, the special char was the last one of the query.
+     * Call backtracking to process this char normally (it's not a filter)
+     */
+    private fun filter(list: List<Char>, query: MutableQuery, backtracking: () -> MutableQuery): MutableQuery =
+            if (list.isEmpty) backtracking()
+            else {
+                val split = list.splitAt { it == ' ' }
+                if (filterNames.contains(split._1.mkString())) {
+                    query.modifiers.add(split._1)
+                    neutral(split._2, query)
+                } else {
+                    backtracking()
+                }
+            }
+
+
+    /**
+     * We are reading a filter ('/' char)
+     *
+     * # Read the directory filter
+     * # Check if it's a valid directory filter (can contains '/')
+     * ## If yes, add it, then process the rest of the string as normal String (neutral state)
+     * ## If no, trigger backtracking
+     *
+     * If End of Stream reached, the special char was the last one of the query.
+     * Call backtracking to process this char normally (it's not a filter)
+     */
+    private fun directory(list: List<Char>, query: MutableQuery, backtracking: () -> MutableQuery): MutableQuery =
+            if (list.isEmpty) backtracking()
+            else {
+                val split = list.splitAt { it == ' ' }
+                val isValidDirectoryChar: (Char) -> Boolean = {
+                    it.isLetterOrDigit() || List.of('_', '-', '/').contains(it)
+                }
+                if (split._1.all(isValidDirectoryChar)) {
+                    query.directories.add(split._1)
+                    neutral(split._2, query)
+                } else {
+                    backtracking()
+                }
+            }
+
+    /**
+     * We are reading a query term (a.k.a. not a special trigger)
+     *
+     * This method deals with double quote and simple quote.
+     * If the first char is a double/simple quote, read the rest of the String ignoring special trigger until the pair
+     * is matched
+     * If the pair doesn't match, backtrack to a normal reading (the double/simple quote will be part of the query)
+     *
+     * If End of Stream reached, simply return the built query
+     */
+    private fun query(list: List<Char>, query: MutableQuery): MutableQuery =
+            if (list.isEmpty) query
+            else {
+                fun readUntil(c: Char, backtracking: () -> MutableQuery) =
+                        list.tail().splitAt { it == c }.let { split ->
+                                    // use .let for this special purpose: https://www.youtube.com/watch?v=Wt88GMJmVk0
+                                    if (split._2.isEmpty) backtracking() // pair is not matched
+                                    else {
+                                        query.term.addAll(split._1)
+                                        neutral(split._2.tail(), query)
+                                    }
+                                }
+
+                val readWord = {
+                    // make sure to consume at leat one char even if it's a space: https://www.youtube.com/watch?v=zI339U6GS9s
+                    query.term.add(list.head())
+                    val split = list.tail().splitAt { it == ' ' }
+                    query.term.addAll(split._1)
+                    neutral(split._2, query)
+                }
+
+                when (list.head()) {
+                    '\'' -> readUntil('\'') { readWord() }
+                    '"' -> readUntil('"') { readWord() }
+                    else -> {
+                        readWord()
+                    }
+                }
+            }
+}
+
+fun String.parseSearch() {
+
+    println(ContextParser(List.of("ok", "foo", "bar")).parse(this))
+
+}
+
+// TODO replace with unit test
+fun main(args: Array<String>) {
+    "test".parseSearch()
+    "test!".parseSearch()
+    "test!ok".parseSearch()
+    "test !ok".parseSearch()
+    "test !ok !foo".parseSearch()
+    "test !ok !foo !bar".parseSearch()
+    "'test !ok !foo !bar'".parseSearch()
+    "'test !ok !foo !bar".parseSearch()
+    "test !ok !foo !autre un chien        qui passe !foo                ".parseSearch()
+    "test !ok /src".parseSearch()
+    "test !ok /src/main/kotlin /src/test/kotlin".parseSearch()
+    "https://www.youtube.com/watch?v=4bPGxLxogvw".parseSearch()
+}

--- a/core/src/test/kotlin/com/github/ktoolz/parser/ParserSpecs.kt
+++ b/core/src/test/kotlin/com/github/ktoolz/parser/ParserSpecs.kt
@@ -1,0 +1,141 @@
+package com.github.ktoolz.parser
+
+import com.github.ktoolz.model.FilterQuery
+import javaslang.collection.List
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.spek.api.Spek
+
+/*
+ * File Finder - KToolZ
+ *
+ * Copyright (c) 2016
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+class ParserSpecs : Spek() { init {
+
+    given("a search query without: filter, directory, quote") {
+        val (term, contexts, directories) = ContextParser(List.empty()).parse("foo")
+
+        on("checking term content") { it("should be equals to the query") { assertThat(term).isEqualTo("foo") } }
+        on("checking contexts") { it("should be empty") { assertThat(contexts).isEmpty() } }
+        on("checking directories") { it("should be empty") { assertThat(directories).isEmpty() } }
+    }
+
+    given("a search query with trailing spaces") {
+        val (term, contexts, directories) = ContextParser(List.empty()).parse("foo              ")
+
+        on("checking term content") {
+            it("should be equals to the query without trailing spaces") {
+                assertThat(term).isEqualTo("foo")
+            }
+        }
+        on("checking contexts") { it("should be empty") { assertThat(contexts).isEmpty() } }
+        on("checking directories") { it("should be empty") { assertThat(directories).isEmpty() } }
+    }
+
+    given("a search query ending with a exclamation mark") {
+        val (term, contexts, directories) = ContextParser(List.empty()).parse("foo !")
+
+        on("checking term content") {
+            it("should be equals to the query including the exlamation mark") {
+                assertThat(term).isEqualTo("foo !")
+            }
+        }
+        on("checking contexts") { it("should be empty") { assertThat(contexts).isEmpty() } }
+        on("checking directories") { it("should be empty") { assertThat(directories).isEmpty() } }
+    }
+
+    given("a search query ending with a slash") {
+        val (term, contexts, directories) = ContextParser(List.empty()).parse("foo /")
+
+        on("checking term content") {
+            it("should be equals to the query including the slash") {
+                assertThat(term).isEqualTo("foo /")
+            }
+        }
+        on("checking contexts") { it("should be empty") { assertThat(contexts).isEmpty() } }
+        on("checking directories") { it("should be empty") { assertThat(directories).isEmpty() } }
+    }
+
+    given("a search query with slash and exclamation mark with no space before them") {
+        val (term, contexts, directories) = ContextParser(List.empty()).parse("foo/bar!goo")
+
+        on("checking term content") {
+            it("should be equals to the query including the slash and the exclamation mark") {
+                assertThat(term).isEqualTo("foo/bar!goo")
+            }
+        }
+        on("checking contexts") { it("should be empty") { assertThat(contexts).isEmpty() } }
+        on("checking directories") { it("should be empty") { assertThat(directories).isEmpty() } }
+    }
+
+    given("a search query with a valid filter query at the beginning") {
+        val (term, contexts, directories) = ContextParser(List.of("foo")).parse("!foo bar")
+
+        on("checking term content") {
+            it("should be equals to the search query without the filer query") {
+                assertThat(term).isEqualTo("bar")
+            }
+        }
+        on("checking contexts") {
+            it("should contains exactly the filter query") {
+                assertThat(contexts).containsExactly(FilterQuery("foo"))
+            }
+        }
+        on("checking directories") { it("should be empty") { assertThat(directories).isEmpty() } }
+    }
+
+    given("a search query with a valid filter query at the beginning and another one at the end") {
+        val (term, contexts, directories) = ContextParser(List.of("foo", "goo")).parse("!foo bar !goo")
+
+        on("checking term content") {
+            it("should be equals to the search query without the filer queries") {
+                assertThat(term).isEqualTo("bar")
+            }
+        }
+        on("checking contexts") {
+            it("should contains exactly the filter query") {
+                assertThat(contexts).containsExactly(FilterQuery("foo"), FilterQuery("goo"))
+            }
+        }
+        on("checking directories") { it("should be empty") { assertThat(directories).isEmpty() } }
+    }
+
+    given("a search query with a valid negated filter query") {
+        val (term, contexts, directories) = ContextParser(List.of("foo")).parse("!!foo bar")
+
+        on("checking term content") {
+            it("should be equals to the search query without the filer query") {
+                assertThat(term).isEqualTo("bar")
+            }
+        }
+        on("checking contexts") {
+            it("should contains exactly the filter query and it should be negated") {
+                assertThat(contexts).containsExactly(FilterQuery("foo", true))
+            }
+        }
+        on("checking directories") { it("should be empty") { assertThat(directories).isEmpty() } }
+    }
+
+
+    given("a search query with an invalid filter query") {
+        val (term, contexts, directories) = ContextParser(List.empty()).parse("!!foo bar")
+
+        on("checking term content") {
+            it("should be equals to the input string") {
+                assertThat(term).isEqualTo("!!foo bar")
+            }
+        }
+        on("checking contexts") {
+            it("should be empty") { assertThat(contexts).isEmpty() }
+        }
+        on("checking directories") { it("should be empty") { assertThat(directories).isEmpty() } }
+    }
+
+}
+}

--- a/gui/src/main/kotlin/com/github/ktoolz/view/MainView.kt
+++ b/gui/src/main/kotlin/com/github/ktoolz/view/MainView.kt
@@ -40,6 +40,10 @@ class MainView : View() {
         (root.scene.lookup("#tableView") as TableView<SearchResult>)
     }
 
+    val inputSearch: TextField by lazy {
+        root.scene.lookup("#inputSearch") as TextField
+    }
+
 
     init {
         title = messages["title"]
@@ -87,7 +91,7 @@ class MainView : View() {
 
                     setOnKeyPressed { event ->
                         when (event.code) {
-                            UP, PAGE_UP, HOME -> if (this.selectedItem == result.first()) scene.lookup("#inputSearch").requestFocus()
+                            UP, PAGE_UP, HOME -> if (this.selectedItem == result.first()) inputSearch.requestFocus()
                             ESCAPE -> scene.lookup("#inputSearch").requestFocus()
                             LEFT, RIGHT -> println("Display action menu!") // TODO display the menu
                         }
@@ -103,7 +107,7 @@ class MainView : View() {
             }
         }
 
-        runAsync { files = load(File("..")) } success { println("Loaded!") } ui { root.scene.lookup("#inputSearch").castUse(TextField::class.java) { this.isDisable = false } }
+        runAsync { files = load(File("..")) } success { println("Loaded!") } ui { inputSearch.isDisable = false }
 
     }
 
@@ -122,9 +126,7 @@ class MainView : View() {
         }
         val toSearchResult: (File) -> SearchResult = { file ->
             val lowerCaseName = file.name.toLowerCase()
-            SearchResult(lowerCaseName.score(lowerCaseSearch, minScore),
-                         file.name,
-                         file)
+            SearchResult(lowerCaseName.score(lowerCaseSearch, minScore), file)
         }
         return files.map(toSearchResult)
                 .map(ponderation)


### PR DESCRIPTION
Hello,

This pull resquest is a proposal for adding a "Context" to search ("context" is not the definitive word we have to discuss to find a (may be) better name)

Context Search allow to extends possibilities of the regular search by:
- Allow filtering results by their directories. Example "pom.xml /myproject" will display every "pom.xml" files which are located inside a directory named "myproject" (at any deep)
- Add a kind of "meta filter" like DuckDuckGo "Bang": https://duckduckgo.com/bang. Example: "DemoApp !sources" will search for a file named "DemoApp" excluding all files which are not sources (sources can be defined as: *.kt, *.java, *.c, ...)

The parser only have to parse (obviously) and doesn't interfer with the actual search process.
